### PR TITLE
Unicode::CharName was throwing a warning.

### DIFF
--- a/lib/Unicode/CharName.pm
+++ b/lib/Unicode/CharName.pm
@@ -77,7 +77,7 @@ sub uname {
 	    return join("", "HANGUL SYLLABLE ", @s)
 	}
     }
-    _init_names() unless defined %NAMES;
+    _init_names() unless %NAMES;
     $NAMES{sprintf("%04X",$code)}
 }
 


### PR DESCRIPTION
defined(%hash) has been depreciated since at least Perl 5.8.8 (and
possibly longer), and throws a warning. So don't do that anymore.

The warning was

defined(%hash) is deprecated at
/usr/local/lib/perl5/site_perl/5.16.1/darwin-2level/Unicode/CharName.pm
line 80.
     (Maybe you should just omit the defined()?)
